### PR TITLE
Update node initialization

### DIFF
--- a/src/odometry2.cpp
+++ b/src/odometry2.cpp
@@ -206,7 +206,8 @@ void Odometry2::pixhawkOdomCallback(const px4_msgs::msg::VehicleOdometry::Unique
 
 /* ControlInterfaceDiagnosticsCallback //{ */
 void Odometry2::ControlInterfaceDiagnosticsCallback([[maybe_unused]] const fog_msgs::msg::ControlInterfaceDiagnostics::UniquePtr msg) {
-  if (!is_initialized_) {
+
+  if (!is_initialized_ || (msg->vehicle_state.state == fog_msgs::msg::ControlInterfaceVehicleState::NOT_CONNECTED)){ 
     return;
   }
 


### PR DESCRIPTION
The odometry routine starts with setting px4 parameters, so wait until the MAVSDK is connected. 